### PR TITLE
Update bower version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,13 @@
 {
   "name": "angular-audio",
-  "private": true,
+  "version": "1.0.0",
+  "description": "Total awesomeness for playing sounds in AngularJS",
   "main":"app/angular.audio.js",
+  "homepage": "http://danielstern.github.io/ngAudio/",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/danielstern/ngAudio.git"
+  }
   "dependencies": {
     "bootstrap": "~3.2.0",
     "angular": "~1.2.23",


### PR DESCRIPTION
Some small changes to the bower.json file. If you also tag the commit with the version number (1.0.0) than you can refer it in bower as version 1.0.0 . Which is handy so it doesn't break if you make any big changes.

https://github.com/bower/bower.json-spec#name
https://help.github.com/articles/about-releases
