### PR TITLE
fix bower dependencies to allow for more than just angular 1.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,6 @@
     "url": "git://github.com/danielstern/ngAudio.git"
   },
   "dependencies": {
-    "angular": ">=1.2 <= 1.4"
+    "angular": ">=1.2 < 1.5"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,6 @@
     "url": "git://github.com/danielstern/ngAudio.git"
   },
   "dependencies": {
-    "angular": "~1.4.0"
+    "angular": ">=1.2 <= 1.4"
   }
 }


### PR DESCRIPTION
see #73 

a lot of people still need angular 1.2 and 1.3 because of other dependencies. since this works in all 3 versions, it should be less restricted. 