### PR TITLE
Fix: check if duration is finite

### DIFF
--- a/app/angular.audio.js
+++ b/app/angular.audio.js
@@ -184,7 +184,7 @@ angular.module('ngAudio', [])
         };
 
         this.setProgress = function(progress) {
-            if (audio && audio.duration) {
+            if (audio && audio.duration && isFinite(progress)) {
                 audio.currentTime = audio.duration * progress;
             }
         };


### PR DESCRIPTION
I kept receiving the following stacktraces, this fixed the issue for me:

```
TypeError: Failed to set the 'currentTime' property on 'HTMLMediaElement': The provided double value is non-finite.
    at TypeError (native)
    at setProgress (http://localhost:9000/bower_components/angular-audio/app/angular.audio.js:188:35)
    at Object.fn (http://localhost:9000/bower_components/angular-audio/app/angular.audio.js:214:33)
    at Scope.$get.Scope.$digest (http://localhost:9000/bower_components/angular/angular.js:15667:29)
    at Scope.$get.Scope.$apply (http://localhost:9000/bower_components/angular/angular.js:15935:24)
    at tick (http://localhost:9000/bower_components/angular/angular.js:11076:36)
```