### PR TITLE
deregister unlock/twiddle handler on audio play

### DIFF
--- a/app/angular.audio.js
+++ b/app/angular.audio.js
@@ -142,14 +142,14 @@ angular.module('ngAudio', [])
 .factory('NgAudioObject', ['cleverAudioFindingService', '$rootScope', '$interval', '$timeout', 'ngAudioGlobals', function(cleverAudioFindingService, $rootScope, $interval, $timeout, ngAudioGlobals) {
     return function(id) {
 
+        function twiddle(){
+            audio.play();
+            audio.pause();
+            window.removeEventListener("click",twiddle);
+        }
+
         if (ngAudioGlobals.unlock) {
-
-            window.addEventListener("click",function twiddle(){
-                audio.play();
-                audio.pause();
-                window.removeEventListener("click",twiddle);
-            });
-
+            window.addEventListener("click",twiddle);
         }
 
 
@@ -260,6 +260,12 @@ angular.module('ngAudio', [])
         cleverAudioFindingService.find(id)
             .then(function(nativeAudio) {
                 audio = nativeAudio;
+                if (ngAudioGlobals.unlock) {
+                  audio.addEventListener('playing', function() {
+                    window.removeEventListener("click",twiddle);
+                  });
+                }
+
                 audio.addEventListener('canplay', function() {
                     audioObject.canPlay = true;
                 });


### PR DESCRIPTION
we can deregister the handler safely once audio is playing
even if user has not clicked yet

Enables Scenario:

Given I have a desktop browser
And unlock is activated by ngAudioGlobals.unlock = true
And I open a page which autoplays a track on load
Then the track will start playing

When I click anywhere on the page
Then the track is not paused

While mobile keeps working fine