### PR TITLE
Potential fix for calling play on an uninitialized object

### DIFF
--- a/app/angular.audio.js
+++ b/app/angular.audio.js
@@ -150,17 +150,6 @@ angular.module('ngAudio', [])
 .factory('NgAudioObject', ['cleverAudioFindingService', '$rootScope', '$interval', '$timeout', 'ngAudioGlobals', function(cleverAudioFindingService, $rootScope, $interval, $timeout, ngAudioGlobals) {
     return function(id, scope) {
 
-        if (ngAudioGlobals.unlock) {
-
-            window.addEventListener("click",function twiddle(){
-                audio.play();
-                audio.pause();
-                window.removeEventListener("click",twiddle);
-            });
-
-        }
-
-
         var $audioWatch,
             $intervalWatch,
             $willPlay = false,
@@ -296,6 +285,16 @@ angular.module('ngAudio', [])
         cleverAudioFindingService.find(id)
             .then(function(nativeAudio) {
                 audio = nativeAudio;
+                if (ngAudioGlobals.unlock) {
+
+                    window.addEventListener("click",function twiddle(){
+                        audio.play();
+                        audio.pause();
+                        window.removeEventListener("click",twiddle);
+                    });
+
+                }
+
                 audio.addEventListener('canplay', function() {
                     audioObject.canPlay = true;
                 });


### PR DESCRIPTION
I just deferred adding the click event listener until the promise that
initializes the audio property has resolved.