### PR TITLE
fix JS error in the event that a browser does not support Number.isNaN

### DIFF
--- a/app/angular.audio.js
+++ b/app/angular.audio.js
@@ -481,7 +481,7 @@ angular.module('ngAudio', [])
 
         }
         
-        if (Number.isNaN(output)){
+        if (typeof Number.isNaN === "function" && Number.isNaN(output)){
             debugger;
         }
 


### PR DESCRIPTION
Safari does not support Number.isNaN, so we're getting a undefined is not a function error. This resolves that issue