### PR TITLE
Try to solve issue 93 progress/range bar starts out at 50% before jum…

### DIFF
--- a/app/angular.audio.js
+++ b/app/angular.audio.js
@@ -372,9 +372,15 @@ angular.module('ngAudio', [])
                     audioObject.currentTime = audio.currentTime;
                     audioObject.duration = audio.duration;
                     audioObject.remaining = audio.duration - audio.currentTime;
-                    audioObject.progress = audio.currentTime / audio.duration;
+					audioObject.progress = 0; //We set initial value to 0
                     audioObject.paused = audio.paused;
                     audioObject.src = audio.src;
+                    
+					//After we check if progress is bigger than 0, and we set
+                    var tempProgress = (audio.currentTime / audio.duration);
+                    if(tempProgress  > 0 ){
+                      audioObject.progress = tempProgress;
+                    }                    
                     
                     if (audioObject.currentTime >= audioObject.duration) {
                         completeListeners.forEach(function(listener){


### PR DESCRIPTION
We set initial progress value to 0, and we create a temporal progress value (audio.currentTime / audio.duration). After we check if temporal progress is bigger than 0, and we update progress.