### PR TITLE
'Dismount' loaded audio object - Fix #110

### DIFF
--- a/app/angular.audio.js
+++ b/app/angular.audio.js
@@ -348,8 +348,7 @@ angular.module('ngAudio', [])
                 }
 
                 if ($willRestart) {
-                    audio.pause();
-                    audio.currentTime = 0;
+                    audio.src = 'about:blank';
                     $willRestart = false;
                 }
 


### PR DESCRIPTION
When using the stop() method, we actually need to stop downloading the audio in the background.
Before this PR, stop() was actually pausing the audio and playing it again at the beginning. But for an audio stream, like a webradio, this won't work. So it's important to destroy the audio stream, thus when you will play it again, it will re-load the audio stream and play it at the current "live" time.
Sorry it's complicate to explain :)

Now you can simply do
```javascript
function play() {
    vm.sound = ngAudio.load(filePath);
    vm.sound.play();
    vm.isPlaying = true;
}

function stop() {
    vm.sound.stop();
    vm.isPlaying = false;
}
```