### PR TITLE
Fixes audio hanging after multiple load requests

### DIFF
--- a/app/angular.audio.js
+++ b/app/angular.audio.js
@@ -119,7 +119,6 @@ angular.module('ngAudio', [])
           audioTag.style.display = 'none';
           audioTag.id = ngAudioDomUid;
           audioTag.src = url;
-          audioTag.type = 'audio/mpeg';
           document.body.appendChild(audioTag);
           $sound = document.getElementById(ngAudioDomUid);
           $sound.load();

--- a/app/angular.audio.js
+++ b/app/angular.audio.js
@@ -116,7 +116,7 @@ angular.module('ngAudio', [])
         if (!$sound)
         {
           var audioTag = document.createElement('audio');
-          audioTag.style = 'display: none';
+          audioTag.style.display = 'none';
           audioTag.id = ngAudioDomUid;
           audioTag.src = url;
           audioTag.type = 'audio/mpeg';


### PR DESCRIPTION
remoteAudioFindingService now uses DOM audio (with unique id autogenerated on module load) instead of js audio object. This prevents audio from hanging after multiple load requests.

Fixes #133, no visible problems (possibly some may appear with `type` tag fixed to `audio/mpeg`, but during my research everything was loading fine (even ogg and wav), as this tag is optional and browser is able to change by itself during resource fetching).
