### PR TITLE
fix(audio.restart() callback): audio.restart() problem fix

### DIFF
--- a/app/angular.audio.js
+++ b/app/angular.audio.js
@@ -347,7 +347,8 @@ angular.module('ngAudio', [])
                 }
 
                 if ($willRestart) {
-                    audio.src = 'about:blank';
+                    audio.currentTime = 0;
+                    audio.pause();
                     $willRestart = false;
                 }
 


### PR DESCRIPTION
audio.restart() function is have a problem

-> angular.audio.js:378 Uncaught (in promise) DOMException: The element has no supported sources.

Because this function is due to initiate in the src blank.
like this -> audio.src = 'about:blank';

(comment):In the demo page, press the play button and a stop button alternately you can reproduce this phenomenon.