### PR TITLE
fix: moving gulp and browser-sync to devDependencies, and updating outdated libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,9 @@
     "ngaudio",
     "angular-audio"
   ],
-  "dependencies": {
-    "browser-sync": "^2.7.12",
-    "gulp": "^3.9.0"
-  },
   "devDependencies": {
+    "browser-sync": "^2.14.0",
+    "gulp": "^3.9.1",
     "gulp-gh-pages": "^0.5.2"
   },
   "engines": {


### PR DESCRIPTION
The issue this PR is trying to solve is that there are known transient vulnerabilities in both browser-sync 2.14.0 and gulp 3.9.1 through some of their 3rd party libraries. Because of this, as long as the project states, that it depends on these libraries directly, security tools - like [nsp ](https://nodesecurity.io/)- will mark it as a vulnerable package.

Please check out the output of nsp below for more details:

> (+) 10 vulnerabilities found
 Name           Installed   Patched              Path                                                                                                                                              More Info
 minimatch      2.0.10      >=3.0.2              myproject@0.0.1 > angular-audio@1.7.3 > gulp@3.9.1 > vinyl-fs@0.3.14 > glob-stream@3.1.18 > minimatch@2.0.10                                       https://nodesecurity.io/advisories/118
 minimatch      0.2.14      >=3.0.2              myproject@0.0.1 > angular-audio@1.7.3 > gulp@3.9.1 > vinyl-fs@0.3.14 > glob-watcher@0.0.6 > gaze@0.5.2 > globule@0.1.0 > minimatch@0.2.14          https://nodesecurity.io/advisories/118
 ws             1.0.1       >=1.1.1              myproject@0.0.1 > angular-audio@1.7.3 > browser-sync@2.14.0 > socket.io@1.4.6 > engine.io@1.6.9 > ws@1.0.1                                         https://nodesecurity.io/advisories/120
 negotiator     0.4.9       >= 0.6.1             myproject@0.0.1 > angular-audio@1.7.3 > browser-sync@2.14.0 > socket.io@1.4.6 > engine.io@1.6.9 > accepts@1.1.4 > negotiator@0.4.9                 https://nodesecurity.io/advisories/106
 tough-cookie   2.2.2       >=2.3.0              myproject@0.0.1 > angular-audio@1.7.3 > browser-sync@2.14.0 > localtunnel@1.8.1 > request@2.65.0 > tough-cookie@2.2.2                              https://nodesecurity.io/advisories/130
 negotiator     0.5.3       >= 0.6.1             myproject@0.0.1 > angular-audio@1.7.3 > browser-sync@2.14.0 > serve-index@1.7.3 > accepts@1.2.13 > negotiator@0.5.3                                https://nodesecurity.io/advisories/106
 express        2.5.11      >=3.11 <4 || >=4.5   myproject@0.0.1 > angular-audio@1.7.3 > browser-sync@2.14.0 > browser-sync-ui@0.6.0 > weinre@2.0.0-pre-I0Z7U9OV > express@2.5.11                   https://nodesecurity.io/advisories/8
 qs             0.4.2       >= 1.x               myproject@0.0.1 > angular-audio@1.7.3 > browser-sync@2.14.0 > browser-sync-ui@0.6.0 > weinre@2.0.0-pre-I0Z7U9OV > express@2.5.11 > qs@0.4.2        https://nodesecurity.io/advisories/28
 qs             0.4.2       >= 1.x               myproject@0.0.1 > angular-audio@1.7.3 > browser-sync@2.14.0 > browser-sync-ui@0.6.0 > weinre@2.0.0-pre-I0Z7U9OV > express@2.5.11 > qs@0.4.2        https://nodesecurity.io/advisories/29
 connect        1.9.2       >=2.8.1              myproject@0.0.1 > angular-audio@1.7.3 > browser-sync@2.14.0 > browser-sync-ui@0.6.0 > weinre@2.0.0-pre-I0Z7U9OV > express@2.5.11 > connect@1.9.2   https://nodesecurity.io/advisories/3

I've moved the packages `gulp` and `browser-sync` to the devDependencies, as they are not required in runtime, therefore nsp will not mark the package itself vulnerable.

In case if you merge the PR, please consider creating a new security maintenance release, so that others could start using the new package version as soon as possible.