### PR TITLE
Updated code example to inject NgAudio into the controller.

### DIFF
--- a/app/partial/ngAudioDocs.html
+++ b/app/partial/ngAudioDocs.html
@@ -20,11 +20,13 @@
 
 <code>
     <pre>
-angular.module('yourModule',['ngAudio'])
-.controller("yourController",function($scope,ngAudio){
-    $scope.sound = ngAudio.load("sounds/mySound.mp3"); // returns NgAudioObject
-})  </pre>
+angular.module('yourModule', ['ngAudio'])
+.controller('yourController', ['$scope', 'ngAudio', function ($scope, ngAudio) {
+    $scope.sound = ngAudio.load('sounds/mySound.mp3'); // returns NgAudioObject
+})
+    </pre>
 </code>
+
 <article>
     <h4>ngAudio Service Reference</h4>
     <table class="table table-striped table-bordered table-condensed">


### PR DESCRIPTION
Hi Daniel,

Perhaps you remember me writing to you approximately 8 months ago... Then again, it's quite likely that you don't. Anyway, I wrote an e-mail describing that the documentation seems to be missing a key point in order to NgAudio to work in Angular projects. In my projects, whenever I left out the part where I inject ngAudio into the controller, the debugger would complain that ngAudio was undefined which seems logical to me. So instead of using the following example code:

```
<script>
angular.module('myModule',['ngAudio'])
    .controller('audioDemo',function($scope,ngAudio){
 	$scope.audio = ngAudio.load('mySound.wav');
})
</script>
```

I've rewritten the example code as follows:

```
<script>
angular.module('yourModule', ['ngAudio'])
.controller('yourController', ['$scope', 'ngAudio', function ($scope, ngAudio) {
    $scope.sound = ngAudio.load('sounds/mySound.mp3'); // returns NgAudioObject
})
</script>
```

It took me quite a while to get around to doing this but better late than never.

Best regards,

Erwin Zoer